### PR TITLE
Http connector redirect

### DIFF
--- a/transport/http/src/main/java/org/kaazing/gateway/transport/http/DefaultHttpSession.java
+++ b/transport/http/src/main/java/org/kaazing/gateway/transport/http/DefaultHttpSession.java
@@ -187,6 +187,10 @@ public class DefaultHttpSession extends AbstractBridgeSession<DefaultHttpSession
 
         servicePath = null;
         pathInfo = null;
+
+        // TODO: add and use new HttpResourceAddress "maximum.redirects" option of type Integer, default 5
+        //redirectsAllowed = ((HttpResourceAddress) remoteAddress).getOption(HttpResourceAddress.MAXIMUM_REDIRECTS);
+        redirectsAllowed = 0;
     }
 
     @Override


### PR DESCRIPTION
Added support for following redirects (status 302) in HttpConnector. 

@jfallows Please review

@mjolie Here are the changes I promised you. Please merge this PR into your branch (hopefully I chose the right branch: jphbalancer, if not, let me know). Then you'll need to add the following:

- tests
- new HttpResourceAddress option to limit how many times we will follow a redirect for a given connection (default 0 so behavior remains as at present: do not follow). I think you already added a Boolean option so it's just a matter of renaming it and changing the type.
- Undo the changes you did to WsnConnector since those will not be needed now.